### PR TITLE
Update formatter.js

### DIFF
--- a/lib/formatter.js
+++ b/lib/formatter.js
@@ -21,7 +21,7 @@ const createFormatter = client => ({ type }, value) => {
 const defaultFormatter = {
   json: value => {
     if (typeof value === 'object') return value;
-    return JSON.parse(value);
+     return value ?  JSON.parse(value) : null;
   },
   boolean: value => {
     if (typeof value === 'boolean') {


### PR DESCRIPTION
fixed for `SyntaxError: Unexpected end of JSON input` when migrating from SQLite to MariaDB

```
SyntaxError: Unexpected end of JSON input
    at JSON.parse (<anonymous>)
    at Object.json (/opt/homebrew/var/www/Sites/mason2-strapi/node_modules/strapi-connector-bookshelf/lib/formatter.js:24:17)
    at /opt/homebrew/var/www/Sites/mason2-strapi/node_modules/strapi-connector-bookshelf/lib/formatter.js:15:27
    at /opt/homebrew/var/www/Sites/mason2-strapi/node_modules/strapi-connector-bookshelf/lib/mount-models.js:630:37
    at Array.forEach (<anonymous>)
    at formatEntry (/opt/homebrew/var/www/Sites/mason2-strapi/node_modules/strapi-connector-bookshelf/lib/mount-models.js:624:41)
    at Child.<anonymous> (/opt/homebrew/var/www/Sites/mason2-strapi/node_modules/strapi-connector-bookshelf/lib/mount-models.js:638:13)
    at /opt/homebrew/var/www/Sites/mason2-strapi/node_modules/bookshelf/lib/base/events.js:101:64
    at tryCatcher (/opt/homebrew/var/www/Sites/mason2-strapi/node_modules/bluebird/js/release/util.js:16:23)
    at Object.gotValue (/opt/homebrew/var/www/Sites/mason2-strapi/node_modules/bluebird/js/release/reduce.js:166:18)
    at Object.gotAccum (/opt/homebrew/var/www/Sites/mason2-strapi/node_modules/bluebird/js/release/reduce.js:155:25)
    at Object.tryCatcher (/opt/homebrew/var/www/Sites/mason2-strapi/node_modules/bluebird/js/release/util.js:16:23)
    at Promise._settlePromiseFromHandler (/opt/homebrew/var/www/Sites/mason2-strapi/node_modules/bluebird/js/release/promise.js:547:31)
    at Promise._settlePromise (/opt/homebrew/var/www/Sites/mason2-strapi/node_modules/bluebird/js/release/promise.js:604:18)
    at Promise._settlePromiseCtx (/opt/homebrew/var/www/Sites/mason2-strapi/node_modules/bluebird/js/release/promise.js:641:10)
    at _drainQueueStep (/opt/homebrew/var/www/Sites/mason2-strapi/node_modules/bluebird/js/release/async.js:97:12)
From previous event:
    at Child.triggerThen (/opt/homebrew/var/www/Sites/mason2-strapi/node_modules/bookshelf/lib/base/events.js:101:20)
    at /opt/homebrew/var/www/Sites/mason2-strapi/node_modules/bookshelf/lib/eager.js:99:58
From previous event:
    at /opt/homebrew/var/www/Sites/mason2-strapi/node_modules/bookshelf/lib/eager.js:99:22
From previous event:
    at EagerRelation._eagerLoadHelper (/opt/homebrew/var/www/Sites/mason2-strapi/node_modules/bookshelf/lib/eager.js:98:8)
From previous event:
    at /opt/homebrew/var/www/Sites/mason2-strapi/node_modules/bookshelf/lib/eager.js:96:73
From previous event:
    at EagerRelation._eagerLoadHelper (/opt/homebrew/var/www/Sites/mason2-strapi/node_modules/bookshelf/lib/eager.js:83:23)
    at Sync.<anonymous> (/opt/homebrew/var/www/Sites/mason2-strapi/node_modules/bookshelf/lib/eager.js:31:31)
From previous event:
    at EagerRelation.eagerFetch (/opt/homebrew/var/www/Sites/mason2-strapi/node_modules/bookshelf/lib/eager.js:31:8)
    at EagerRelation.<anonymous> (/opt/homebrew/var/www/Sites/mason2-strapi/node_modules/bookshelf/lib/base/eager.js:67:14)
From previous event:
    at Child._handleEager (/opt/homebrew/var/www/Sites/mason2-strapi/node_modules/bookshelf/lib/collection.js:527:73)
    at Child.<anonymous> (/opt/homebrew/var/www/Sites/mason2-strapi/node_modules/bookshelf/lib/collection.js:179:27)
    at processImmediate (node:internal/timers:466:21)
From previous event:
    at Child.<anonymous> (/opt/homebrew/var/www/Sites/mason2-strapi/node_modules/bookshelf/lib/collection.js:177:12)
From previous event:
    at Child.fetchAll (/opt/homebrew/var/www/Sites/mason2-strapi/node_modules/bookshelf/lib/model.js:878:10)
    at Object.random (/opt/homebrew/var/www/Sites/mason2-strapi/api/collection/controllers/collection.js:20:8)
    at dispatch (/opt/homebrew/var/www/Sites/mason2-strapi/node_modules/koa-router/node_modules/koa-compose/index.js:44:32)
    at next (/opt/homebrew/var/www/Sites/mason2-strapi/node_modules/koa-router/node_modules/koa-compose/index.js:45:18)
    at dispatch (/opt/homebrew/var/www/Sites/mason2-strapi/node_modules/koa-compose/index.js:42:32)
    at /opt/homebrew/var/www/Sites/mason2-strapi/node_modules/strapi/lib/middlewares/router/utils/routerChecker.js:79:28
    at dispatch (/opt/homebrew/var/www/Sites/mason2-strapi/node_modules/koa-compose/index.js:42:32)
    at module.exports (/opt/homebrew/var/www/Sites/mason2-strapi/node_modules/strapi-plugin-users-permissions/config/policies/permissions.js:88:9)
    at async /opt/homebrew/var/www/Sites/mason2-strapi/node_modules/strapi-utils/lib/policy.js:68:5
    at async serve (/opt/homebrew/var/www/Sites/mason2-strapi/node_modules/koa-static/index.js:59:5)
    at async /opt/homebrew/var/www/Sites/mason2-strapi/node_modules/strapi/lib/middlewares/parser/index.js:48:23
    at async /opt/homebrew/var/www/Sites/mason2-strapi/node_modules/strapi/lib/middlewares/xss/index.js:26:9
[2022-03-08T10:28:08.410Z] debug GET /collections/random (94 ms) 500
```

